### PR TITLE
ListCrossoverPipeline: fixing bug in C_TWO_POINT crossover (#75)

### DIFF
--- a/ecj/src/main/java/ec/vector/breed/ListCrossoverPipeline.java
+++ b/ecj/src/main/java/ec/vector/breed/ListCrossoverPipeline.java
@@ -317,7 +317,7 @@ public class ListCrossoverPipeline extends BreedingPipeline
                                 split[i][1] = temp;
                                 }
                                         
-                            int len = split[i][0] - split[i][1];
+                            int len = split[i][1] - split[i][0];
                             if (len >= min_chunks[i] && len <= max_chunks[i])  // okay
                                 {
                                 split[i][0] *= chunk_size;


### PR DESCRIPTION
This improves the situation of https://github.com/GMUEClab/ecj/issues/75

Now I see some new individuals. However, there are still few individuals that are reported as being created from two parents, but are just exact copy of one of them.