### PR TITLE
ListCrossoverPipeline: report second parent only if actually used

### DIFF
--- a/ecj/src/main/java/ec/vector/breed/ListCrossoverPipeline.java
+++ b/ecj/src/main/java/ec/vector/breed/ListCrossoverPipeline.java
@@ -376,7 +376,8 @@ public class ListCrossoverPipeline extends BreedingPipeline
             inds.add(parents.get(0));
             if (preserveParents != null)
                 {
-                parentparents[0].addAll(parentparents[1]);
+                if(valid_children == true)
+                    parentparents[0].addAll(parentparents[1]);
                 preserveParents[q] = parentparents[0];
                 }
             q++;


### PR DESCRIPTION
If using `misc` to keep parents' indices, it used to always keep the indices of both parents even if if the reproduction failed, and the individual is just a copy of a single parent. Now it always keep the index of the first parent, and adds the index of the second parent only if it's really used.